### PR TITLE
Changing subclass constructors to private

### DIFF
--- a/src/main/java/org/imsglobal/caliper/entities/Collection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/Collection.java
@@ -36,7 +36,7 @@ public class Collection extends AbstractEntity implements CaliperCollection<Cali
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Collection(Builder<?> builder) {
+    private Collection(Builder<?> builder) {
         super(builder);
         this.items = ImmutableList.copyOf(builder.items);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/Entity.java
+++ b/src/main/java/org/imsglobal/caliper/entities/Entity.java
@@ -26,7 +26,7 @@ public class Entity extends AbstractEntity {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Entity(Builder<?> builder) {
+    private Entity(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Agent.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Agent.java
@@ -26,7 +26,7 @@ public class Agent extends AbstractEntity implements CaliperAgent {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Agent(Builder<?> builder) {
+    private Agent(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/agent/CourseOffering.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/CourseOffering.java
@@ -33,7 +33,7 @@ public class CourseOffering extends AbstractCourse {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected CourseOffering(Builder<?> builder) {
+    private CourseOffering(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/agent/CourseSection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/CourseSection.java
@@ -41,7 +41,7 @@ public class CourseSection extends AbstractCourse {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected CourseSection(Builder<?> builder) {
+    private CourseSection(Builder<?> builder) {
         super(builder);
         this.category = builder.category;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Group.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Group.java
@@ -28,7 +28,7 @@ public class Group extends AbstractOrganization {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Group(Builder<?> builder) {
+    private Group(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Membership.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Membership.java
@@ -51,7 +51,7 @@ public class Membership extends AbstractEntity {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Membership(Builder<?> builder) {
+    private Membership(Builder<?> builder) {
         super(builder);
 
         this.member = builder.member;

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Organization.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Organization.java
@@ -28,7 +28,7 @@ public class Organization extends AbstractOrganization implements CaliperOrganiz
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Organization(Builder<?> builder) {
+    private Organization(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Person.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Person.java
@@ -26,7 +26,7 @@ public class Person extends AbstractEntity implements CaliperAgent {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Person(Builder<?> builder) {
+    private Person(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/Annotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/Annotation.java
@@ -28,7 +28,7 @@ public class Annotation extends AbstractAnnotation {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Annotation(Builder<?> builder) {
+    private Annotation(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/BookmarkAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/BookmarkAnnotation.java
@@ -31,7 +31,7 @@ public class BookmarkAnnotation extends AbstractAnnotation {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected BookmarkAnnotation(Builder<?> builder) {
+    private BookmarkAnnotation(Builder<?> builder) {
         super(builder);
         this.bookmarkNotes = builder.bookmarkNotes;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/HighlightAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/HighlightAnnotation.java
@@ -35,7 +35,7 @@ public class HighlightAnnotation extends AbstractAnnotation {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected HighlightAnnotation(Builder<?> builder) {
+    private HighlightAnnotation(Builder<?> builder) {
         super(builder);
         this.selection = builder.selection;
         this.selectionText = builder.selectionText;

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/SharedAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/SharedAnnotation.java
@@ -35,7 +35,7 @@ public class SharedAnnotation extends AbstractAnnotation {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected SharedAnnotation(Builder<?> builder) {
+    private SharedAnnotation(Builder<?> builder) {
         super(builder);
         this.withAgents = ImmutableList.copyOf(builder.withAgents);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/TagAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/TagAnnotation.java
@@ -34,7 +34,7 @@ public class TagAnnotation extends AbstractAnnotation {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected TagAnnotation(Builder<?> builder) {
+    private TagAnnotation(Builder<?> builder) {
         super(builder);
         this.tags = ImmutableList.copyOf(builder.tags);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Attempt.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Attempt.java
@@ -56,7 +56,7 @@ public class Attempt extends AbstractEntity implements CaliperGeneratable {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Attempt(Builder<?> builder) {
+    private Attempt(Builder<?> builder) {
         super(builder);
 
         EntityValidator.checkStartTime(builder.timePeriod.getStartedAtTime(), builder.timePeriod.getEndedAtTime());

--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Result.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Result.java
@@ -47,7 +47,7 @@ public class Result extends AbstractEntity implements CaliperGeneratable {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Result(Builder<?> builder) {
+    private Result(Builder<?> builder) {
         super(builder);
 
         this.attempt = builder.attempt;

--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Score.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Score.java
@@ -47,7 +47,7 @@ public class Score extends AbstractEntity implements CaliperGeneratable {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Score(Builder<?> builder) {
+    private Score(Builder<?> builder) {
         super(builder);
 
         this.attempt = builder.attempt;

--- a/src/main/java/org/imsglobal/caliper/entities/question/Question.java
+++ b/src/main/java/org/imsglobal/caliper/entities/question/Question.java
@@ -29,7 +29,7 @@ public class Question extends AbstractQuestion {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Question(Builder<?> builder) {
+    private Question(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/question/RatingScaleQuestion.java
+++ b/src/main/java/org/imsglobal/caliper/entities/question/RatingScaleQuestion.java
@@ -33,7 +33,7 @@ public class RatingScaleQuestion extends AbstractQuestion {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected RatingScaleQuestion(Builder<?> builder) {
+    private RatingScaleQuestion(Builder<?> builder) {
         super(builder);
         this.scale = builder.scale;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Assessment.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Assessment.java
@@ -38,7 +38,7 @@ public class Assessment extends AssignableDigitalResource implements CaliperAsse
     /**
      * @param builder apply builder object properties to the CaliperAssessment object.
      */
-    protected Assessment(Builder<?> builder) {
+    private Assessment(Builder<?> builder) {
         super(builder);
         this.items = ImmutableList.copyOf(builder.items);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/resource/AssessmentItem.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/AssessmentItem.java
@@ -34,7 +34,7 @@ public class AssessmentItem extends AbstractAssignableDigitalResource implements
     /**
      * @param builder apply builder object properties to the AssessmentItem object.
      */
-    protected AssessmentItem(Builder<?> builder) {
+    private AssessmentItem(Builder<?> builder) {
         super(builder);
         this.isTimeDependent = builder.isTimeDependent;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/resource/AudioObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/AudioObject.java
@@ -43,7 +43,7 @@ public class AudioObject extends AbstractMediaObject implements CaliperMediaObje
     /**
      * @param builder apply builder object properties to the AudioObject object.
      */
-    protected AudioObject(Builder<?> builder) {
+    private AudioObject(Builder<?> builder) {
         super(builder);
         this.volumeMin = builder.volumeMin;
         this.volumeMax = builder.volumeMax;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Chapter.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Chapter.java
@@ -25,7 +25,7 @@ public class Chapter extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Chapter(Builder<?> builder) {
+    private Chapter(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/DigitalResource.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/DigitalResource.java
@@ -28,7 +28,7 @@ public class DigitalResource extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected DigitalResource(Builder<?> builder) {
+    private DigitalResource(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/DigitalResourceCollection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/DigitalResourceCollection.java
@@ -35,7 +35,7 @@ public class DigitalResourceCollection extends AbstractDigitalResource implement
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected DigitalResourceCollection(Builder<?> builder) {
+    private DigitalResourceCollection(Builder<?> builder) {
         super(builder);
 
         this.items = ImmutableList.copyOf(builder.items);

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Document.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Document.java
@@ -25,7 +25,7 @@ public class Document extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Document(Builder<?> builder) {
+    private Document(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Forum.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Forum.java
@@ -35,7 +35,7 @@ public class Forum extends AbstractDigitalResource implements CaliperCollection<
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Forum(Builder<?> builder) {
+    private Forum(Builder<?> builder) {
         super(builder);
 
         this.items = ImmutableList.copyOf(builder.items);

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Frame.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Frame.java
@@ -29,7 +29,7 @@ public class Frame extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Frame(Builder<?> builder) {
+    private Frame(Builder<?> builder) {
         super(builder);
 
         this.index = builder.index;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/ImageObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/ImageObject.java
@@ -30,7 +30,7 @@ public class ImageObject extends AbstractMediaObject implements CaliperMediaObje
     /**
      * @param builder apply builder object properties to the ImageObject object.
      */
-    protected ImageObject(Builder<?> builder) {
+    private ImageObject(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/LearningObjective.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/LearningObjective.java
@@ -27,7 +27,7 @@ public class LearningObjective extends AbstractEntity {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected LearningObjective(Builder<?> builder) {
+    private LearningObjective(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/MediaLocation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/MediaLocation.java
@@ -33,7 +33,7 @@ public class MediaLocation extends AbstractDigitalResource implements CaliperTar
     /**
      * @param builder apply builder object properties to the MediaLocation object.
      */
-    protected MediaLocation(Builder<?> builder) {
+    private MediaLocation(Builder<?> builder) {
         super(builder);
 
         this.currentTime = builder.currentTime;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/MediaObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/MediaObject.java
@@ -31,7 +31,7 @@ public class MediaObject extends AbstractMediaObject implements CaliperMediaObje
     /**
      * @param builder apply builder object properties to the MediaObject object.
      */
-    protected MediaObject(Builder<?> builder) {
+    private MediaObject(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Message.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Message.java
@@ -40,7 +40,7 @@ public class Message extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Message(Builder<?> builder) {
+    private Message(Builder<?> builder) {
         super(builder);
 
         this.replyTo = builder.replyTo;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Page.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Page.java
@@ -25,7 +25,7 @@ public class Page extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Page(Builder<?> builder) {
+    private Page(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Questionnaire.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Questionnaire.java
@@ -35,7 +35,7 @@ public class Questionnaire extends AbstractDigitalResource implements CaliperCol
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Questionnaire(Builder<?> builder) {
+    private Questionnaire(Builder<?> builder) {
         super(builder);
 
         this.items = ImmutableList.copyOf(builder.items);

--- a/src/main/java/org/imsglobal/caliper/entities/resource/QuestionnaireItem.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/QuestionnaireItem.java
@@ -45,7 +45,7 @@ public class QuestionnaireItem extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the QuestionnaireItem object.
      */
-    protected QuestionnaireItem(Builder<?> builder) {
+    private QuestionnaireItem(Builder<?> builder) {
         super(builder);
         this.categories = ImmutableList.copyOf(builder.categories);
         this.question = builder.question;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Thread.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Thread.java
@@ -35,7 +35,7 @@ public class Thread extends AbstractDigitalResource implements CaliperCollection
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Thread(Builder<?> builder) {
+    private Thread(Builder<?> builder) {
         super(builder);
 
         this.items = ImmutableList.copyOf(builder.items);

--- a/src/main/java/org/imsglobal/caliper/entities/resource/VideoObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/VideoObject.java
@@ -30,7 +30,7 @@ public class VideoObject extends AbstractMediaObject implements CaliperMediaObje
     /**
      * @param builder apply builder object properties to the VideoObject object.
      */
-    protected VideoObject(Builder<?> builder) {
+    private VideoObject(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/WebPage.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/WebPage.java
@@ -25,7 +25,7 @@ public class WebPage extends AbstractDigitalResource {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected WebPage(Builder<?> builder) {
+    private WebPage(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/response/FillinBlankResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/FillinBlankResponse.java
@@ -37,7 +37,7 @@ public class FillinBlankResponse extends AbstractResponse {
     /**
      * @param builder apply builder object properties to the Response object.
      */
-    protected FillinBlankResponse(Builder<?> builder) {
+    private FillinBlankResponse(Builder<?> builder) {
         super(builder);
         this.values = ImmutableList.copyOf(builder.values);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/response/MultipleChoiceResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/MultipleChoiceResponse.java
@@ -33,7 +33,7 @@ public class MultipleChoiceResponse extends AbstractResponse {
     /**
      * @param builder apply builder object properties to the Response object.
      */
-    protected MultipleChoiceResponse(Builder<?> builder) {
+    private MultipleChoiceResponse(Builder<?> builder) {
         super(builder);
         this.value = builder.value;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/response/MultipleResponseResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/MultipleResponseResponse.java
@@ -39,7 +39,7 @@ public class MultipleResponseResponse extends AbstractResponse {
     /**
      * @param builder apply builder object properties to the Response object.
      */
-    protected MultipleResponseResponse(Builder<?> builder) {
+    private MultipleResponseResponse(Builder<?> builder) {
         super(builder);
         this.values = ImmutableList.copyOf(builder.values);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/response/Response.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/Response.java
@@ -25,7 +25,7 @@ public class Response extends AbstractResponse {
     /**
      * @param builder apply builder object properties to the Response object.
      */
-    protected Response(Builder<?> builder) { super(builder); }
+    private Response(Builder<?> builder) { super(builder); }
 
     /**
      * Builder class provides a fluid interface for setting object properties.

--- a/src/main/java/org/imsglobal/caliper/entities/response/SelectTextResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/SelectTextResponse.java
@@ -37,7 +37,7 @@ public class SelectTextResponse extends AbstractResponse {
     /**
      * @param builder apply builder object properties to the Response object.
      */
-    protected SelectTextResponse(Builder<?> builder) {
+    private SelectTextResponse(Builder<?> builder) {
         super(builder);
         this.values = ImmutableList.copyOf(builder.values);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/response/TrueFalseResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/TrueFalseResponse.java
@@ -34,7 +34,7 @@ public class TrueFalseResponse extends AbstractResponse {
     /**
      * @param builder apply builder object properties to the Response object.
      */
-    protected TrueFalseResponse(Builder<?> builder) {
+    private TrueFalseResponse(Builder<?> builder) {
         super(builder);
         this.value = builder.value;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/scale/LikertScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/LikertScale.java
@@ -42,7 +42,7 @@ public class LikertScale extends AbstractEntity implements CaliperScale {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected LikertScale(Builder<?> builder) {
+    private LikertScale(Builder<?> builder) {
         super(builder);
         this.itemLabels = ImmutableList.copyOf(builder.itemLabels);
         this.itemValues = ImmutableList.copyOf(builder.itemValues);

--- a/src/main/java/org/imsglobal/caliper/entities/scale/MultiselectScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/MultiselectScale.java
@@ -51,7 +51,7 @@ public class MultiselectScale extends AbstractEntity implements CaliperScale {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected MultiselectScale(Builder<?> builder) {
+    private MultiselectScale(Builder<?> builder) {
         super(builder);
         this.isOrderedSelection = builder.isOrderedSelection;
         this.itemLabels = ImmutableList.copyOf(builder.itemLabels);

--- a/src/main/java/org/imsglobal/caliper/entities/scale/NumericScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/NumericScale.java
@@ -46,7 +46,7 @@ public class NumericScale extends AbstractEntity implements CaliperScale {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected NumericScale(Builder<?> builder) {
+    private NumericScale(Builder<?> builder) {
         super(builder);
         this.maxLabel = builder.maxLabel;
         this.minLabel = builder.minLabel;

--- a/src/main/java/org/imsglobal/caliper/entities/scale/Scale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/Scale.java
@@ -27,7 +27,7 @@ public class Scale extends AbstractEntity implements CaliperScale {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Scale(Builder<?> builder) {
+    private Scale(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/entities/search/Query.java
+++ b/src/main/java/org/imsglobal/caliper/entities/search/Query.java
@@ -38,7 +38,7 @@ public class Query extends AbstractEntity {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Query(Builder<?> builder) {
+    private Query(Builder<?> builder) {
         super(builder);
         this.creator = builder.creator;
         this.searchTarget = builder.searchTarget;

--- a/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
@@ -41,7 +41,7 @@ public class SearchResponse extends AbstractEntity implements CaliperGeneratable
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected SearchResponse(Builder<?> builder) {
+    private SearchResponse(Builder<?> builder) {
         super(builder);
         this.searchProvider = builder.searchProvider;
         this.searchTarget = builder.searchTarget;

--- a/src/main/java/org/imsglobal/caliper/entities/session/LtiSession.java
+++ b/src/main/java/org/imsglobal/caliper/entities/session/LtiSession.java
@@ -31,7 +31,7 @@ public class LtiSession extends AbstractSession {
     /**
      * @param builder apply builder object properties to the LtiSession object.
      */
-    protected LtiSession(Builder<?> builder) {
+    private LtiSession(Builder<?> builder) {
         super(builder);
         this.messageParameters = builder.messageParameters;
     }

--- a/src/main/java/org/imsglobal/caliper/entities/session/Session.java
+++ b/src/main/java/org/imsglobal/caliper/entities/session/Session.java
@@ -25,7 +25,7 @@ public class Session extends AbstractSession {
     /**
      * @param builder apply builder object properties to the Session object.
      */
-    protected Session(Builder<?> builder) { super(builder); }
+    private Session(Builder<?> builder) { super(builder); }
 
     /**
      * Builder class provides a fluid interface for setting object properties.

--- a/src/main/java/org/imsglobal/caliper/entities/survey/Comment.java
+++ b/src/main/java/org/imsglobal/caliper/entities/survey/Comment.java
@@ -39,7 +39,7 @@ public class Comment extends AbstractEntity implements CaliperGeneratable {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Comment(Builder<?> builder) {
+    private Comment(Builder<?> builder) {
         super(builder);
         this.commenter = builder.commenter;
         this.commentedOn = builder.commentedOn;

--- a/src/main/java/org/imsglobal/caliper/entities/survey/Rating.java
+++ b/src/main/java/org/imsglobal/caliper/entities/survey/Rating.java
@@ -49,7 +49,7 @@ public class Rating extends AbstractEntity implements CaliperGeneratable {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Rating(Builder<?> builder) {
+    private Rating(Builder<?> builder) {
         super(builder);
         this.question = builder.question;
         this.rater = builder.rater;

--- a/src/main/java/org/imsglobal/caliper/entities/survey/Survey.java
+++ b/src/main/java/org/imsglobal/caliper/entities/survey/Survey.java
@@ -38,7 +38,7 @@ public class Survey extends AbstractEntity implements CaliperCollection<Question
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Survey(Builder<?> builder) {
+    private Survey(Builder<?> builder) {
         super(builder);
         this.items = ImmutableList.copyOf(builder.items);
     }

--- a/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasure.java
+++ b/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasure.java
@@ -50,7 +50,7 @@ public class AggregateMeasure extends AbstractEntity {
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected AggregateMeasure(Builder<?> builder) {
+    private AggregateMeasure(Builder<?> builder) {
         super(builder);
         this.metric = builder.metric;
         this.metricValue = builder.metricValue;

--- a/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasureCollection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasureCollection.java
@@ -34,7 +34,7 @@ public class AggregateMeasureCollection extends AbstractEntity implements Calipe
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected AggregateMeasureCollection(Builder<?> builder) {
+    private AggregateMeasureCollection(Builder<?> builder) {
         super(builder);
         this.items = ImmutableList.copyOf(builder.items);
     }

--- a/src/main/java/org/imsglobal/caliper/events/AbstractEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AbstractEvent.java
@@ -65,7 +65,7 @@ public abstract class AbstractEvent implements CaliperEvent {
     private final CaliperAgent actor;
 
     @JsonProperty("action")
-    protected final CaliperAction action;
+    private final CaliperAction action;
 
     @JsonProperty("object")
     private final CaliperEntity object;

--- a/src/main/java/org/imsglobal/caliper/events/AnnotationEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AnnotationEvent.java
@@ -59,7 +59,7 @@ public class AnnotationEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected AnnotationEvent(Builder<?> builder) {
+    private AnnotationEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.ANNOTATION);

--- a/src/main/java/org/imsglobal/caliper/events/AssessmentEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AssessmentEvent.java
@@ -60,7 +60,7 @@ public class AssessmentEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected AssessmentEvent(Builder<?> builder) {
+    private AssessmentEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.ASSESSMENT);

--- a/src/main/java/org/imsglobal/caliper/events/AssessmentItemEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AssessmentItemEvent.java
@@ -55,7 +55,7 @@ public class AssessmentItemEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected AssessmentItemEvent(Builder<?> builder) {
+    private AssessmentItemEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.ASSESSMENT_ITEM);

--- a/src/main/java/org/imsglobal/caliper/events/AssignableEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AssignableEvent.java
@@ -52,7 +52,7 @@ public class AssignableEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected AssignableEvent(Builder<?> builder) {
+    private AssignableEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.ASSIGNABLE);

--- a/src/main/java/org/imsglobal/caliper/events/Event.java
+++ b/src/main/java/org/imsglobal/caliper/events/Event.java
@@ -55,7 +55,7 @@ public class Event extends AbstractEvent {
      *
      * @param builder
      */
-    protected Event(Builder<?> builder) {
+    private Event(Builder<?> builder) {
         super(builder);
     }
 

--- a/src/main/java/org/imsglobal/caliper/events/FeedbackEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/FeedbackEvent.java
@@ -48,7 +48,7 @@ public class FeedbackEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected FeedbackEvent(Builder<?> builder) {
+    private FeedbackEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.FEEDBACK);

--- a/src/main/java/org/imsglobal/caliper/events/ForumEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ForumEvent.java
@@ -52,7 +52,7 @@ public class ForumEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected ForumEvent(Builder<?> builder) {
+    private ForumEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.FORUM);

--- a/src/main/java/org/imsglobal/caliper/events/GradeEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/GradeEvent.java
@@ -50,7 +50,7 @@ public class GradeEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected GradeEvent(Builder<?> builder) {
+    private GradeEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.GRADE);

--- a/src/main/java/org/imsglobal/caliper/events/MediaEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/MediaEvent.java
@@ -70,7 +70,7 @@ public class MediaEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected MediaEvent(Builder<?> builder) {
+    private MediaEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.MEDIA);

--- a/src/main/java/org/imsglobal/caliper/events/MessageEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/MessageEvent.java
@@ -53,7 +53,7 @@ public class MessageEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected MessageEvent(Builder<?> builder) {
+    private MessageEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.MESSAGE);

--- a/src/main/java/org/imsglobal/caliper/events/NavigationEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/NavigationEvent.java
@@ -45,7 +45,7 @@ public class NavigationEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected NavigationEvent(Builder<?> builder) {
+    private NavigationEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.NAVIGATION);

--- a/src/main/java/org/imsglobal/caliper/events/ResourceManagementEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ResourceManagementEvent.java
@@ -67,7 +67,7 @@ public class ResourceManagementEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected ResourceManagementEvent(Builder<?> builder) {
+    private ResourceManagementEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.RESOURCE_MANAGEMENT);

--- a/src/main/java/org/imsglobal/caliper/events/SearchEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/SearchEvent.java
@@ -50,7 +50,7 @@ public class SearchEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected SearchEvent(Builder<?> builder) {
+    private SearchEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.SEARCH);

--- a/src/main/java/org/imsglobal/caliper/events/SessionEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/SessionEvent.java
@@ -45,7 +45,7 @@ public class SessionEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected SessionEvent(Builder<?> builder) {
+    private SessionEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.SESSION);

--- a/src/main/java/org/imsglobal/caliper/events/ThreadEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ThreadEvent.java
@@ -52,7 +52,7 @@ public class ThreadEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected ThreadEvent(Builder<?> builder) {
+    private ThreadEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.THREAD);

--- a/src/main/java/org/imsglobal/caliper/events/ToolLaunchEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ToolLaunchEvent.java
@@ -54,7 +54,7 @@ public class ToolLaunchEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected ToolLaunchEvent(Builder<?> builder) {
+    private ToolLaunchEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.TOOL_LAUNCH);

--- a/src/main/java/org/imsglobal/caliper/events/ToolUseEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ToolUseEvent.java
@@ -56,7 +56,7 @@ public class ToolUseEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected ToolUseEvent(Builder<?> builder) {
+    private ToolUseEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.TOOL_USE);

--- a/src/main/java/org/imsglobal/caliper/events/ViewEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ViewEvent.java
@@ -49,7 +49,7 @@ public class ViewEvent extends AbstractEvent {
      *
      * @param builder
      */
-    protected ViewEvent(Builder<?> builder) {
+    private ViewEvent(Builder<?> builder) {
         super(builder);
 
         EventValidator.checkType(this.getType(), EventType.VIEW);


### PR DESCRIPTION
This PR aims to make the project more consistent and secure by changing all possible Event or Entity constructors from `protected` to `private`. Though some more recently added classes already had `private` constructors, others needed to be updated. I could not update the `Abstract` classes, since their constructors are used by the Entity and Event subclasses. I also could not update the constructor for `AssignableDigitalResource`, as it threw a compilation error, apparently related to the use of `Assignment` in `AbstractAssignableDigitalResource`, although I'm not absolutely certain. I also changed the `CaliperAction` property on `AbstractEvent` to `private`, as all the other properties had that designation; no tests broke as a result.